### PR TITLE
Handle systems without telldir()

### DIFF
--- a/t/symdump.t
+++ b/t/symdump.t
@@ -134,7 +134,7 @@ for $type ( qw{
 	}
     }
 
-    ok (@syms >= $Expect{$type});
+    ok (@syms >= $Expect{$type}, $type);
 }
 
 exit;


### PR DESCRIPTION
To discover whether a glob points to a dirhandle on
those systems, some B trickery is required.

..in the real world, this is really just for Android.
